### PR TITLE
Compile aginst cgnt enabled mpich and openmpi

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,18 +8,19 @@ source:
   md5: 4f7d8126d7367c239fd67615680990e3
 
 build:
-  number: 2          [linux]
-  number: 1          [win]
+  number: 3          [linux]
+  number: 2          [win]
   detect_binary_files_with_prefix: True
 
 requirements:
   build:
     - python
-    - mpich2         [linux]
+    - '{{ compiler("c") }}'
+    - mpich         [linux]
     - openmpi        [osx]
   run:
     - python
-    - mpich2         [linux]
+    - mpich         [linux]
     - openmpi        [osx]
 
 test:


### PR DESCRIPTION
which were updated to  mpich3 and openmpi3. 
This shall go after 
https://github.com/AnacondaRecipes/mpich-feedstock/pull/1
and
https://github.com/AnacondaRecipes/openmpi-feedstock/pull/1
are addressed.

@mingwandroid This is the third PR regarding the mpich and openmpi recipe updates. Are there other packages that use MPI on anaconda? I'll be happy to work on PRs to port all of them to the new mpich/openmpi packages.
